### PR TITLE
Unable to register via org_id, activationkey and poolids

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     server_proxy_password: "{{ sap_rhsm_proxy_password | default(omit) }}"
     force_register: "{{ sap_rhsm_force_register | default(omit) }}"
   when: (sap_rhsm_username is defined and sap_rhsm_password is defined) or
-        (activationkey is defined and org_id is defined)
+        (sap_rhsm_activationkey is defined and sap_rhsm_org_id is defined)
 
 - name: 'Ensure RHEL minor release is locked to SAP certified release'
   command: 'subscription-manager release --set={{ ansible_distribution_version }}'


### PR DESCRIPTION
Unable to register via org_id, activationkey and poolids only due to register step is skipped.